### PR TITLE
Add Migration "Update1" to handle Development column on AgentType

### DIFF
--- a/Migrations/20200208232315_Update1.Designer.cs
+++ b/Migrations/20200208232315_Update1.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Faction.Common.Backend.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Faction.Common.Migrations
 {
     [DbContext(typeof(FactionDbContext))]
-    partial class FactionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200208232315_Update1")]
+    partial class Update1
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20200208232315_Update1.cs
+++ b/Migrations/20200208232315_Update1.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Faction.Common.Migrations
+{
+    public partial class Update1 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Development",
+                table: "AgentType",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Development",
+                table: "AgentType");
+        }
+    }
+}


### PR DESCRIPTION
Since the CLI handles migrations, this probably went unnoticed. However, the FactionCompose project pulls the Migrations from Faction.Common. The PR simply updates the current migrations with the changes by adding a new Migration file. 

Command used to generate migration (future reference):

```
$ dotnet ef migrations add --startup-project ./../Core/ Update1 --context Faction.Common.Backend.Database.FactionDbContext
````